### PR TITLE
encode: support passing formats and output type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 coverage.*
 *.sqlite*
 ./transcoder
+downloads

--- a/encoder/arguments_test.go
+++ b/encoder/arguments_test.go
@@ -1,0 +1,69 @@
+package encoder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/lbryio/transcoder/formats"
+)
+
+func TestNewArguments(t *testing.T) {
+	var (
+		out = t.TempDir()
+		fps = 30
+
+		defaultFormats = []formats.Format{
+			{
+				Resolution: formats.SD144,
+				Bitrate:    formats.Bitrate{FPS30: 100, FPS60: 160},
+			},
+		}
+	)
+
+	tests := []struct {
+		name          string
+		targetType    TargetType
+		targetFormats []formats.Format
+		wantArgs      Arguments
+		wantErr       bool
+	}{
+		{
+			"HLS",
+			TargetTypeHLS, defaultFormats,
+			HLSArguments(),
+			false,
+		},
+		{
+			"TS",
+			TargetTypeTS, defaultFormats,
+			TSArguments(),
+			false,
+		},
+		{
+			"DefaultToHLS",
+			TargetTypeUnknown, defaultFormats,
+			HLSArguments(),
+			false,
+		},
+		{
+			"EmptyFormats",
+			TargetTypeUnknown, nil,
+			HLSArguments(),
+			true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			target := Target{test.targetFormats, test.targetType}
+			gotArgs, gotErr := NewArguments(out, target, fps)
+			if test.wantErr {
+				assert.NotNil(t, gotErr)
+			} else {
+				assert.Nil(t, gotErr)
+				assert.Equal(t, test.wantArgs.defaultArgs, gotArgs.defaultArgs)
+			}
+		})
+	}
+}

--- a/encoder/encoder_test.go
+++ b/encoder/encoder_test.go
@@ -24,21 +24,16 @@ func TestEncoderSuite(t *testing.T) {
 }
 
 func (s *encoderSuite) SetupSuite() {
-	s.out = path.Join(os.TempDir(), "encoderSuite_out")
+	s.out = path.Join(s.T().TempDir(), "encoderSuite_out")
 
 	url := "@specialoperationstest#3/fear-of-death-inspirational#a"
 	c, err := manager.ResolveRequest(url)
 	if err != nil {
 		panic(err)
 	}
-	s.file, _, err = c.Download(path.Join(os.TempDir(), "encoderSuite_in"))
+	s.file, _, err = c.Download(path.Join(s.T().TempDir(), "encoderSuite_in"))
 	s.file.Close()
 	s.Require().NoError(err)
-}
-
-func (s *encoderSuite) TearDownSuite() {
-	os.Remove(s.file.Name())
-	os.RemoveAll(s.out)
 }
 
 func (s *encoderSuite) TestEncode() {


### PR DESCRIPTION
This enable support to encode to specific target type instead of just
the default HLS output.